### PR TITLE
Add support for azurerm 2.x and azurecaf providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0 (March 2020)
+
+FEATURES: 
+* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#6](https://github.com/aztfmod/terraform-azurerm-caf-azure-firewall/issues/6))
+
+IMPROVEMENTS:
+* **improvement:**  Changing to resource_group_name instead of rg.
+
 ## v1.1 (January 2020)
 
 FEATURES: 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ module "az_firewall" {
     version = "0.x.y"
 
     name                              = var.az_fw_name
-    rg                                = var.virtual_network_rg
+    resource_group_name               = var.virtual_network_rg
     subnet_id                         = var.subnetid
     public_ip_id                      = var.pip.id
     location                          = var.location["region1"]
@@ -26,7 +26,7 @@ module "az_firewall" {
 | Name | Type | Default | Description | 
 | -- | -- | -- | -- | 
 | name | string | None | Specifies the name of the Container Registry. Changing this forces a new resource to be created. |
-| rg | string | None | The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created. |
+| resource_group_name | string | None | The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created. |
 | location | string | None | Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  | 
 | tags | map | None | Map of tags for the deployment.  | 
 | la_workspace_id | string | None | Log Analytics Repository ID. | 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build status](https://dev.azure.com/azure-terraform/Blueprints/_apis/build/status/modules/azure_firewall)](https://dev.azure.com/azure-terraform/Blueprints/_build/latest?definitionId=11)
+[![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 # Deploys Azure Firewall
 Creates an Azure Firewall in a given region
 
@@ -34,7 +35,9 @@ module "az_firewall" {
 | subnet_id | string | None | ID for the subnet where to deploy the Azure Firewall  | 
 | public_ip_id | string | None | ID for the public IP to deploy the Azure Firewall | 
 | convention | string | None | Naming convention to be used (check at the naming convention module for possible values).  | 
-| prefix | string | None | Prefix to be used (to be deprecated)  | 
+| prefix | string | None | (Optional) Prefix to be used. |
+| postfix | string | None | (Optional) Postfix to be used. |
+| max_length | string | None | (Optional) maximum length to the name of the resource. |
 
 ## Output
 

--- a/examples/firewall/application_rule_tags.tf
+++ b/examples/firewall/application_rule_tags.tf
@@ -1,19 +1,19 @@
-# resource "azurerm_firewall_application_rule_collection" "tags_rule" {
-#   name                = "Authorize_fqdntags"
-#   azure_firewall_name = module.firewall_test.name
-#   resource_group_name = module.rg_test.names.test
-#   priority            = 101
-#   action              = "Allow"
+resource "azurerm_firewall_application_rule_collection" "tags_rule" {
+  name                = "Authorize_fqdntags"
+  azure_firewall_name = module.firewall_test.name
+  resource_group_name = azurerm_resource_group.rg_test.name
+  priority            = 101
+  action              = "Allow"
 
-#   rule {
-#     name = "Azure_Services"
+  rule {
+    name = "Azure_Services"
 
-#     source_addresses = [
-#       "10.0.0.0/16",
-#     ]
+    source_addresses = [
+      "10.0.0.0/16",
+    ]
 
-#     fqdn_tags = [
-#       "AzureBackup", "MicrosoftActiveProtectionService", "WindowsUpdate",
-#     ]
-#   }
-# }
+    fqdn_tags = [
+      "AzureBackup", "MicrosoftActiveProtectionService", "WindowsUpdate",
+    ]
+  }
+}

--- a/examples/firewall/application_rule_tags.tf
+++ b/examples/firewall/application_rule_tags.tf
@@ -1,19 +1,19 @@
-resource "azurerm_firewall_application_rule_collection" "tags_rule" {
-  name                = "Authorize_fqdntags"
-  azure_firewall_name = module.firewall_test.name
-  resource_group_name = module.rg_test.names.test
-  priority            = 101
-  action              = "Allow"
+# resource "azurerm_firewall_application_rule_collection" "tags_rule" {
+#   name                = "Authorize_fqdntags"
+#   azure_firewall_name = module.firewall_test.name
+#   resource_group_name = module.rg_test.names.test
+#   priority            = 101
+#   action              = "Allow"
 
-  rule {
-    name = "Azure_Services"
+#   rule {
+#     name = "Azure_Services"
 
-    source_addresses = [
-      "10.0.0.0/16",
-    ]
+#     source_addresses = [
+#       "10.0.0.0/16",
+#     ]
 
-    fqdn_tags = [
-      "AzureBackup", "MicrosoftActiveProtectionService", "WindowsUpdate",
-    ]
-  }
-}
+#     fqdn_tags = [
+#       "AzureBackup", "MicrosoftActiveProtectionService", "WindowsUpdate",
+#     ]
+#   }
+# }

--- a/examples/firewall/firewall.tf
+++ b/examples/firewall/firewall.tf
@@ -9,9 +9,8 @@ resource "azurerm_resource_group" "rg_test" {
 }
 
 module "la_test" {
-  # source  = "aztfmod/caf-log-analytics/azurerm"
-  # version = "1.0.0"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-log-analytics?ref=2003-refresh"
+  source  = "aztfmod/caf-log-analytics/azurerm"
+  version = "2.0.0"
   
     convention          = local.convention
     location            = local.location
@@ -23,9 +22,8 @@ module "la_test" {
 }
 
 module "diags_test" {
-  # source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  # version = "1.0.0"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-diagnostics-logging?ref=2003-refresh"
+  source  = "aztfmod/caf-diagnostics-logging/azurerm"
+  version = "2.0.0"
 
   name                  = local.name
   convention            = local.convention
@@ -37,10 +35,8 @@ module "diags_test" {
 }
 
 module "vnet_test" {
-  # source  = "aztfmod/caf-virtual-network/azurerm"
-  # version = "0.2.0"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-virtual-network?ref=2003-refresh-2"
-
+  source  = "aztfmod/caf-virtual-network/azurerm"
+  version = "2.0.0"
     
   virtual_network_rg                = azurerm_resource_group.rg_test.name
   prefix                            = local.prefix
@@ -55,9 +51,8 @@ module "vnet_test" {
 }
 
 module "public_ip_test" {
-  # source  = "aztfmod/caf-public-ip/azurerm"
-  # version = "0.1.3"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-public-ip?ref=2003-refresh"
+  source  = "aztfmod/caf-public-ip/azurerm"
+  version = "2.0.0"
 
   name                             = local.ip_addr_config.ip_name
   location                         = local.location

--- a/examples/firewall/firewall.tf
+++ b/examples/firewall/firewall.tf
@@ -1,32 +1,35 @@
-module "rg_test" {
-  source  = "aztfmod/caf-resource-group/azurerm"
-  version = "0.1.1"
-  
-    prefix          = local.prefix
-    resource_groups = local.resource_groups
-    tags            = local.tags
+provider "azurerm" {
+   features {}
+}
+
+resource "azurerm_resource_group" "rg_test" {
+  name     = local.resource_groups.test.name
+  location = local.resource_groups.test.location
+  tags     = local.tags
 }
 
 module "la_test" {
-  source  = "aztfmod/caf-log-analytics/azurerm"
-  version = "1.0.0"
+  # source  = "aztfmod/caf-log-analytics/azurerm"
+  # version = "1.0.0"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-log-analytics?ref=2003-refresh"
   
     convention          = local.convention
     location            = local.location
     name                = local.name
     solution_plan_map   = local.solution_plan_map 
     prefix              = local.prefix
-    resource_group_name = module.rg_test.names.test
+    resource_group_name = azurerm_resource_group.rg_test.name
     tags                = local.tags
 }
 
 module "diags_test" {
-  source  = "aztfmod/caf-diagnostics-logging/azurerm"
-  version = "1.0.0"
+  # source  = "aztfmod/caf-diagnostics-logging/azurerm"
+  # version = "1.0.0"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-diagnostics-logging?ref=2003-refresh"
 
   name                  = local.name
   convention            = local.convention
-  resource_group_name   = module.rg_test.names.test
+  resource_group_name   = azurerm_resource_group.rg_test.name
   prefix                = local.prefix
   location              = local.location
   tags                  = local.tags
@@ -34,10 +37,12 @@ module "diags_test" {
 }
 
 module "vnet_test" {
-  source  = "aztfmod/caf-virtual-network/azurerm"
-  version = "0.2.0"
+  # source  = "aztfmod/caf-virtual-network/azurerm"
+  # version = "0.2.0"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-virtual-network?ref=2003-refresh"
+
     
-  virtual_network_rg                = module.rg_test.names.test
+  virtual_network_rg                = azurerm_resource_group.rg_test.name
   prefix                            = local.prefix
   location                          = local.location
   networking_object                 = local.vnet_config
@@ -45,20 +50,23 @@ module "vnet_test" {
   diagnostics_map                   = module.diags_test.diagnostics_map
   log_analytics_workspace           = module.la_test
   diagnostics_settings              = local.vnet_config.diagnostics
+  convention                        = local.convention
 }
 
 module "public_ip_test" {
-  source  = "aztfmod/caf-public-ip/azurerm"
-  version = "0.1.3"
+  # source  = "aztfmod/caf-public-ip/azurerm"
+  # version = "0.1.3"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-public-ip?ref=2003-refresh"
 
   name                             = local.ip_addr_config.ip_name
   location                         = local.location
-  rg                               = module.rg_test.names.test
+  rg                               = azurerm_resource_group.rg_test.name
   ip_addr                          = local.ip_addr_config
   tags                             = local.tags
   diagnostics_map                  = module.diags_test.diagnostics_map
   log_analytics_workspace_id       = module.la_test.id
   diagnostics_settings             = local.ip_addr_config.diagnostics
+  convention                       = local.convention
 }
 
 module "firewall_test" {
@@ -66,7 +74,7 @@ module "firewall_test" {
   
   convention                  = local.convention
   name                        = local.az_fw_config.name
-  rg                          = module.rg_test.names.test
+  rg                          = azurerm_resource_group.rg_test.name
   location                    = local.location 
   tags                        = local.tags
   la_workspace_id             = module.la_test.id
@@ -75,5 +83,6 @@ module "firewall_test" {
 
   subnet_id                   = lookup(module.vnet_test.vnet_subnets, "AzureFirewallSubnet", null)
   public_ip_id                = module.public_ip_test.id
+  max_length                  = local.max_length
 }
 

--- a/examples/firewall/firewall.tf
+++ b/examples/firewall/firewall.tf
@@ -39,7 +39,7 @@ module "diags_test" {
 module "vnet_test" {
   # source  = "aztfmod/caf-virtual-network/azurerm"
   # version = "0.2.0"
-  source = "git://github.com/aztfmod/terraform-azurerm-caf-virtual-network?ref=2003-refresh"
+  source = "git://github.com/aztfmod/terraform-azurerm-caf-virtual-network?ref=2003-refresh-2"
 
     
   virtual_network_rg                = azurerm_resource_group.rg_test.name
@@ -51,6 +51,7 @@ module "vnet_test" {
   log_analytics_workspace           = module.la_test
   diagnostics_settings              = local.vnet_config.diagnostics
   convention                        = local.convention
+  max_length = 60
 }
 
 module "public_ip_test" {
@@ -74,7 +75,7 @@ module "firewall_test" {
   
   convention                  = local.convention
   name                        = local.az_fw_config.name
-  rg                          = azurerm_resource_group.rg_test.name
+  resource_group_name         = azurerm_resource_group.rg_test.name
   location                    = local.location 
   tags                        = local.tags
   la_workspace_id             = module.la_test.id

--- a/examples/firewall/firewall.tf
+++ b/examples/firewall/firewall.tf
@@ -83,6 +83,5 @@ module "firewall_test" {
 
   subnet_id                   = lookup(module.vnet_test.vnet_subnets, "AzureFirewallSubnet", null)
   public_ip_id                = module.public_ip_test.id
-  max_length                  = local.max_length
 }
 

--- a/examples/firewall/locals.tf
+++ b/examples/firewall/locals.tf
@@ -1,16 +1,17 @@
 locals {
     convention = "cafrandom"
-    name = "caftest-azfw4"
+    name = "azfwcaf"
     location = "southeastasia"
     prefix = ""
+    max_length = 60
     resource_groups = {
         test = { 
-            name     = "test-caf-azfw4"
+            name     = "test-caf-azfirewall"
             location = "southeastasia" 
         },
     }
     enable_event_hub = true
-    #must be set to true while using virtual network v.0.2
+
     tags = {
         environment     = "DEV"
         owner           = "CAF"

--- a/examples/firewall/locals.tf
+++ b/examples/firewall/locals.tf
@@ -3,7 +3,6 @@ locals {
     name = "azfwcaf"
     location = "southeastasia"
     prefix = ""
-    max_length = 60
     resource_groups = {
         test = { 
             name     = "test-caf-azfirewall"

--- a/module.tf
+++ b/module.tf
@@ -11,7 +11,7 @@ resource "azurecaf_naming_convention" "caf_name_afw" {
 resource "azurerm_firewall" "az_firewall" {
   name                = azurecaf_naming_convention.caf_name_afw.result
   location            = var.location 
-  resource_group_name = var.rg
+  resource_group_name = var.resource_group_name
   tags                = local.tags
 
   ip_configuration {
@@ -20,3 +20,4 @@ resource "azurerm_firewall" "az_firewall" {
     public_ip_address_id = var.public_ip_id
   }
 }
+

--- a/module.tf
+++ b/module.tf
@@ -1,15 +1,15 @@
 #Reference: https://www.terraform.io/docs/providers/azurerm/r/firewall.html 
-module "caf_name_afw" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-
-  name    = var.name
-  type    = "afw"
-  convention  = var.convention
+resource "azurecaf_naming_convention" "caf_name_afw" {  
+  name          = var.name
+  prefix        = var.prefix != "" ? var.prefix : null
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
+  resource_type = "azurerm_firewall"
+  convention    = var.convention
 }
 
 resource "azurerm_firewall" "az_firewall" {
-  name                = module.caf_name_afw.afw
+  name                = azurecaf_naming_convention.caf_name_afw.result
   location            = var.location 
   resource_group_name = var.rg
   tags                = local.tags

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,6 @@ variable "postfix" {
 variable "max_length" {
   description = "(Optional) You can speficy a maximum length to the name of the resource"
   type        = string
-  default = ""
+  default = "50"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,22 @@ variable "diagnostics_settings" {
 variable "convention" {
   description = "(Required) Naming convention method to use"  
 }
+
+variable "prefix" {
+  description = "(Optional) You can use a prefix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "postfix" {
+  description = "(Optional) You can use a postfix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "max_length" {
+  description = "(Optional) You can speficy a maximum length to the name of the resource"
+  type        = string
+  default = ""
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "tags" {
   description = "(Required) Tags of the Azure Firewall to be created"  
 }
 
-variable "rg" {
+variable "resource_group_name" {
   description = "(Required) Resource Group of the Azure Firewall to be created"  
 }
 


### PR DESCRIPTION
## v2.0 (March 2020)

FEATURES: 
* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#6](https://github.com/aztfmod/terraform-azurerm-caf-azure-firewall/issues/6))

IMPROVEMENTS:
* **improvement:**  Changing to resource_group_name instead of rg.